### PR TITLE
fix: generate GraphQL ID scalar as string|number type 

### DIFF
--- a/packages/example-plugin/e2e/types/generated-admin-types.ts
+++ b/packages/example-plugin/e2e/types/generated-admin-types.ts
@@ -8,7 +8,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
+  ID: { input: string | number; output: string | number; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
@@ -6674,7 +6674,7 @@ export type GetExampleEntityListQueryVariables = Exact<{
 }>;
 
 
-export type GetExampleEntityListQuery = { __typename?: 'Query', exampleEntities: { __typename?: 'ExampleEntityList', totalItems: number, items: Array<{ __typename?: 'ExampleEntity', id: string, code: string }> } };
+export type GetExampleEntityListQuery = { __typename?: 'Query', exampleEntities: { __typename?: 'ExampleEntityList', totalItems: number, items: Array<{ __typename?: 'ExampleEntity', id: string | number, code: string }> } };
 
 
 export const GetExampleEntityListDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetExampleEntityList"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"options"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ExampleEntityListOptions"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"exampleEntities"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"options"},"value":{"kind":"Variable","name":{"kind":"Name","value":"options"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"code"}}]}},{"kind":"Field","name":{"kind":"Name","value":"totalItems"}}]}}]}}]} as unknown as DocumentNode<GetExampleEntityListQuery, GetExampleEntityListQueryVariables>;

--- a/packages/example-plugin/e2e/types/generated-shop-types.ts
+++ b/packages/example-plugin/e2e/types/generated-shop-types.ts
@@ -8,7 +8,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
+  ID: { input: string | number; output: string | number; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }

--- a/packages/example-plugin/src/generated-admin-types.ts
+++ b/packages/example-plugin/src/generated-admin-types.ts
@@ -7,7 +7,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
+  ID: { input: string | number; output: string | number; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }

--- a/packages/example-plugin/src/generated-shop-types.ts
+++ b/packages/example-plugin/src/generated-shop-types.ts
@@ -7,7 +7,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
+  ID: { input: string | number; output: string | number; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }

--- a/utils/generate-types.ts
+++ b/utils/generate-types.ts
@@ -59,6 +59,7 @@ export async function generateTypes(
             enumValues: 'keep',
         },
         scalars: {
+            ID: 'string | number',
             Money: 'number',
         },
     };


### PR DESCRIPTION
This change ensures the generated GraphQL code supports both strings and numbers for the ID scalar, to match the type of Vendure's 'ID' type.

Currently, in generated GraphQL types, the ID is always of type string. When using these generated TypeScript types, e.g. the UpdateExampleEntityInput type, Vendure's ID type does not match the generated ID type. For example:

```js
const exampleEntity = await this.exampleEntityService.findOne(ctx, id);

await this.exampleEntityService.update(ctx, {
  id: exampleEntity.id, // Error: TS2322: Type ID is not assignable to type string. Type number is not assignable to type string.
  foo: "bar",
});
```

This change matches the code generation config in the Vendure repository (https://github.com/vendure-ecommerce/vendure/blob/master/scripts/codegen/generate-graphql-types.ts).