### PR TITLE
Remove dist folder upon building

### DIFF
--- a/packages/example-plugin/package.json
+++ b/packages/example-plugin/package.json
@@ -16,7 +16,7 @@
     "scripts": {
         "dev": "ts-node dev-server/index.ts",
         "codegen": "ts-node generate-types.ts",
-        "build": "rimraf lib && tsc -p ./tsconfig.build.json && ts-node copy-ui-src.ts",
+        "build": "rimraf dist && tsc -p ./tsconfig.build.json && ts-node copy-ui-src.ts",
         "e2e": "cross-env PACKAGE=example-plugin vitest -c ../../utils/e2e/vitest.config.mts"
     },
     "dependencies": {}


### PR DESCRIPTION
The tsconfig has `dist` as its output, but the package script still followed the older convention of a `lib` folder.